### PR TITLE
fix: improve context window usage calculation in OpenAIResponsesUtility

### DIFF
--- a/utils/open_ai_responses_api_helpers.py
+++ b/utils/open_ai_responses_api_helpers.py
@@ -364,7 +364,8 @@ class OpenAIResponsesUtility:
             
         # Calculate total cost at the end
         cost_USD = cost_USD_initial + cost_USD_tool
-        context_window_usage = context_window_usage_1 + context_window_usage_2
+        # Context window usage is cumulative - use the latest value from tool loop if present, otherwise initial
+        context_window_usage = context_window_usage_2 if context_window_usage_2 != 0 else context_window_usage_1
         if images_1:
             output_images.extend(images_1)
         if images_2:


### PR DESCRIPTION
This pull request updates the logic for calculating the context window usage in the `responses_APIcall` function. Instead of summing the initial and tool loop context window usages, the code now uses the latest value from the tool loop if present, ensuring more accurate tracking of context usage.

* API call logic update:
  * In `utils/open_ai_responses_api_helpers.py`, the calculation for `context_window_usage` now takes the latest value from the tool loop (`context_window_usage_2`) if it exists, otherwise it falls back to the initial value (`context_window_usage_1`). This prevents overcounting and reflects the actual usage more accurately.