### PR TITLE
Ensure sequential tool calls for immediate rendering and execution

### DIFF
--- a/utils/open_ai_responses_api_helpers.py
+++ b/utils/open_ai_responses_api_helpers.py
@@ -123,7 +123,9 @@ class OpenAIResponsesUtility:
         if tools:
             args['tools'] = tools
             args['tool_choice'] = tool_choice
-            args['parallel_tool_calls'] = True
+            # Keep tool calls sequential so each call can render and execute as
+            # soon as the model emits it, instead of batching multiple calls.
+            args['parallel_tool_calls'] = False
 
         if model.startswith('o4'):
             args['tool_choice'] = 'auto'  # Set tool choice to auto for o4 models

--- a/utils/streamlit_helpers.py
+++ b/utils/streamlit_helpers.py
@@ -117,12 +117,14 @@ def render_tool_call(tool_call):
         tool_call: The tool call to render
     """
     arguments = json.loads(tool_call['arguments'])
-    with st.expander(f"🛠️ See Tool Call - Tool Name: {tool_call['name']}", expanded=False):
+    if 'reason' in arguments:
         st.caption(f"Reason: {arguments['reason']}")
+    with st.expander(f"🛠️ See Tool Call - Tool Name: {tool_call['name']}", expanded=False):
         if 'python_expression' in arguments:
             st.code(arguments['python_expression'], language='python')
         if 'function_definition' in arguments:
             st.code(arguments['function_definition'], language='python')
+
 def render_tool_response(tool_response):
     """
     Renders a tool response in the Streamlit UI
@@ -158,4 +160,3 @@ def render_tool_response(tool_response):
             except json.JSONDecodeError:
                 # Not JSON, display as plain text
                 st.write(tool_response)
-

--- a/utils/streamlit_helpers.py
+++ b/utils/streamlit_helpers.py
@@ -116,7 +116,11 @@ def render_tool_call(tool_call):
     Args:
         tool_call: The tool call to render
     """
-    function = tool_call.get('function', {}) if isinstance(tool_call, dict) else {}
+    if not isinstance(tool_call, dict):
+        logging.warning(f'Unexpected tool call shape: {tool_call}')
+        tool_call = {}
+
+    function = tool_call.get('function', {})
     tool_name = tool_call.get('name') or function.get('name') or 'unknown'
     raw_arguments = tool_call.get('arguments') or function.get('arguments') or '{}'
 

--- a/utils/streamlit_helpers.py
+++ b/utils/streamlit_helpers.py
@@ -116,14 +116,28 @@ def render_tool_call(tool_call):
     Args:
         tool_call: The tool call to render
     """
-    arguments = json.loads(tool_call['arguments'])
+    function = tool_call.get('function', {}) if isinstance(tool_call, dict) else {}
+    tool_name = tool_call.get('name') or function.get('name') or 'unknown'
+    raw_arguments = tool_call.get('arguments') or function.get('arguments') or '{}'
+
+    if isinstance(raw_arguments, dict):
+        arguments = raw_arguments
+    else:
+        try:
+            arguments = json.loads(raw_arguments)
+        except (TypeError, json.JSONDecodeError):
+            logging.warning(f'Unable to parse tool call arguments for {tool_name}: {raw_arguments}')
+            arguments = {}
+
     if 'reason' in arguments:
-        st.caption(f"Reason: {arguments['reason']}")
-    with st.expander(f"🛠️ See Tool Call - Tool Name: {tool_call['name']}", expanded=False):
+        st.caption(f"Reason: {safely_escape_dollars(str(arguments['reason']))}")
+    with st.expander(f"🛠️ See Tool Call - Tool Name: {tool_name}", expanded=False):
         if 'python_expression' in arguments:
             st.code(arguments['python_expression'], language='python')
         if 'function_definition' in arguments:
             st.code(arguments['function_definition'], language='python')
+        if not arguments:
+            st.code(str(raw_arguments), language='json')
 
 def render_tool_response(tool_response):
     """


### PR DESCRIPTION
This pull request makes improvements to how tool calls are handled and displayed in the application. The main changes focus on ensuring tool calls are processed sequentially for better real-time feedback and enhancing the user interface by more clearly displaying the reason for each tool call.

**Tool call execution and display improvements:**

* Changed tool call execution to be sequential by setting `parallel_tool_calls` to `False` in `_prepare_api_args`, allowing each tool call to render and execute as soon as it is emitted, rather than batching multiple calls.
* Updated `render_tool_call` in `utils/streamlit_helpers.py` to display the `reason` for the tool call above the expander, making it more visible in the UI.

**Minor UI cleanup:**

* Removed an unnecessary blank line at the end of `render_tool_response` for code cleanliness.