### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/balajikesavan90/future-of-ai-is-open-hackathon/security/code-scanning/1](https://github.com/balajikesavan90/future-of-ai-is-open-hackathon/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/tests.yml` so it applies to all jobs (currently just `pytest`). For this workflow, `contents: read` is the minimal and appropriate permission, since actions used (`checkout`, `setup-python`) and test execution do not require write scopes.

Best single fix without changing functionality:
- Edit `.github/workflows/tests.yml`.
- Insert immediately after the `on:` triggers (before `jobs:`):
  - `permissions:`
  - `  contents: read`

No imports, methods, or additional definitions are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
